### PR TITLE
#3 - hashed CF tunnel name avoid unintended load-balancing issue

### DIFF
--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -14,6 +14,8 @@ Options:
   --hosts LIST       Comma list: root,api,www
   --auto-ports       Auto-select next available port pair
   --auto-detect-ports  Auto-detect Docker ports (default: on)
+  --no-cache         Create Cloudflare cache bypass rule for hostnames (requires Cache Rules/Rulesets Edit)
+  --shared-tunnel    Reuse <app>-<env> tunnel name across machines (HA)
 EOF
 }
 
@@ -72,6 +74,7 @@ log_ports_summary() {
 wait_for_http_ready() {
   local url="$1"
   local label="$2"
+  local reject_404="${3:-false}"
   local tries=30
   local delay=2
   local i
@@ -81,6 +84,10 @@ wait_for_http_ready() {
       :
     else
       code="000"
+    fi
+    if [[ "$reject_404" == "true" && "$code" == "404" ]]; then
+      sleep "$delay"
+      continue
     fi
     if [[ "$code" != "000" && "$code" != "502" && "$code" != "503" && "$code" != "504" ]]; then
       if [[ "$code" == "302" ]]; then
@@ -96,6 +103,45 @@ wait_for_http_ready() {
   return 1
 }
 
+resolve_ready_url() {
+  local url="$1"
+  local redirect
+  redirect="$(curl -s -o /dev/null -w "%{redirect_url}" "$url" || true)"
+  if [[ -n "$redirect" ]]; then
+    echo "$redirect"
+    return 0
+  fi
+  echo "$url"
+}
+
+hash_short() {
+  local input="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$input" | shasum -a 256 | awk '{print substr($1,1,4)}'
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$input" | sha256sum | awk '{print substr($1,1,4)}'
+    return 0
+  fi
+  printf '%s' "$input" | tr -cd 'a-zA-Z0-9' | cut -c1-4
+}
+
+machine_suffix() {
+  local raw=""
+  if [[ -f "/etc/machine-id" ]]; then
+    raw="$(cat /etc/machine-id 2>/dev/null || true)"
+  fi
+  if [[ -z "$raw" ]]; then
+    raw="$(hostname 2>/dev/null || true)"
+  fi
+  if [[ -z "$raw" ]]; then
+    raw="fb"
+  fi
+  hash_short "$raw"
+}
+
+
 cmd_bootstrap() {
   FB_BOOTSTRAP="true"
   local user_ports="false"
@@ -108,6 +154,8 @@ cmd_bootstrap() {
   local auto_ports="false"
   local auto_detect_ports="true"
   local hosts_list=""
+  local no_cache="false"
+  local shared_tunnel="false"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -143,6 +191,14 @@ cmd_bootstrap() {
         ;;
       --auto-detect-ports)
         auto_detect_ports="true"
+        shift
+        ;;
+      --no-cache)
+        no_cache="true"
+        shift
+        ;;
+      --shared-tunnel)
+        shared_tunnel="true"
         shift
         ;;
       -h|--help)
@@ -286,6 +342,10 @@ cmd_bootstrap() {
 
   cf_ensure_zone "$DOMAIN_NAME"
   local tunnel_name="${APP_NAME}-${ENV_NAME}"
+  if [[ "$shared_tunnel" != "true" ]]; then
+    tunnel_name="${tunnel_name}-$(machine_suffix)"
+  fi
+  log_info "Using Cloudflare tunnel: $tunnel_name"
   local tunnel_id
   tunnel_id="$(cf_get_tunnel "$CF_ACCOUNT_ID" "$tunnel_name")"
   if [[ -z "$tunnel_id" ]]; then
@@ -293,6 +353,14 @@ cmd_bootstrap() {
     log_info "Created Cloudflare tunnel: $tunnel_name"
   else
     log_info "Cloudflare tunnel exists: $tunnel_name"
+  fi
+
+  local existing_conn_count
+  existing_conn_count="$(cf_get_tunnel_connections "$CF_ACCOUNT_ID" "$tunnel_id" | jq -r 'length' 2>/dev/null || true)"
+  if [[ -n "$existing_conn_count" && "$existing_conn_count" -gt 0 ]]; then
+    log_warn "Tunnel $tunnel_name already has $existing_conn_count active connection(s)."
+    log_warn "If another machine is still connected, responses may mix and cache inconsistently."
+    log_warn "Stop other connectors or use a different app/env to isolate."
   fi
 
   local target="${tunnel_id}.cfargotunnel.com"
@@ -305,6 +373,23 @@ cmd_bootstrap() {
   if is_true "$HOSTNAME_WWW"; then
     cf_ensure_dns_record "$CF_ZONE_ID" "$WWW_HOSTNAME_OVERRIDE" "$target"
   fi
+  if is_true "$no_cache"; then
+    if is_true "$HOSTNAME_ROOT"; then
+      if ! cf_ensure_cache_bypass_host "$CF_ZONE_ID" "$DOMAIN_NAME"; then
+        log_warn "Failed to set Cloudflare cache bypass for $DOMAIN_NAME (need Cache Rules/Rulesets Edit)."
+      fi
+    fi
+    if is_true "$HOSTNAME_API"; then
+      if ! cf_ensure_cache_bypass_host "$CF_ZONE_ID" "$API_HOSTNAME_OVERRIDE"; then
+        log_warn "Failed to set Cloudflare cache bypass for $API_HOSTNAME_OVERRIDE (need Cache Rules/Rulesets Edit)."
+      fi
+    fi
+    if is_true "$HOSTNAME_WWW"; then
+      if ! cf_ensure_cache_bypass_host "$CF_ZONE_ID" "$WWW_HOSTNAME_OVERRIDE"; then
+        log_warn "Failed to set Cloudflare cache bypass for $WWW_HOSTNAME_OVERRIDE (need Cache Rules/Rulesets Edit)."
+      fi
+    fi
+  fi
 
   local ingress_rules
   ingress_rules="$(build_ingress_rules "$DOMAIN_NAME" "$SITE_PORT" "$API_PORT" "$HOSTNAME_ROOT" "$HOSTNAME_API" "$HOSTNAME_WWW" "$API_HOSTNAME_OVERRIDE" "$WWW_HOSTNAME_OVERRIDE")"
@@ -314,14 +399,32 @@ cmd_bootstrap() {
   local token
   token="$(cloudflare_get_token_or_file "$APP_NAME" "$ENV_NAME" "$CF_ACCOUNT_ID" "$tunnel_id")"
 
-  log_info "Starting cloudflared tunnel"
-  cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
-
   local app_deployed="false"
+  local tunnel_started="false"
   if [[ "$manual_mode" == "true" ]]; then
     log_info "Manual mode: FB does not manage your app process. Start your app separately."
+    log_info "Starting cloudflared tunnel"
+    cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
+    tunnel_started="true"
   elif deploy_app "$ENV_NAME"; then
     app_deployed="true"
+    if [[ -n "$SITE_PORT" ]]; then
+      local local_url="http://localhost:$SITE_PORT"
+      wait_for_http_ready "$local_url" "Local app" || true
+      local ready_url
+      ready_url="$(resolve_ready_url "$local_url")"
+      if [[ "$ready_url" != "$local_url" ]]; then
+        wait_for_http_ready "$ready_url" "Local app (ready)" "true" || true
+      fi
+    fi
+    log_info "Starting cloudflared tunnel"
+    cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
+    tunnel_started="true"
+  else
+    log_warn "App deploy failed; starting tunnel anyway."
+    log_info "Starting cloudflared tunnel"
+    cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
+    tunnel_started="true"
   fi
 
   if [[ "$manual_mode" != "true" ]] && is_true "$auto_detect_ports"; then
@@ -359,8 +462,12 @@ cmd_bootstrap() {
           ingress_rules="$(build_ingress_rules "$DOMAIN_NAME" "$SITE_PORT" "$API_PORT" "$HOSTNAME_ROOT" "$HOSTNAME_API" "$HOSTNAME_WWW" "$API_HOSTNAME_OVERRIDE" "$WWW_HOSTNAME_OVERRIDE")"
           render_cloudflared_config "$APP_NAME" "$ENV_NAME" "$tunnel_id" "$ingress_rules" \
             "$FB_ROOT/templates/cloudflared/config.yml.tmpl"
-          cloudflare_stop_tunnel "$APP_NAME" "$ENV_NAME" || true
-          cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
+          if [[ "$tunnel_started" == "true" ]]; then
+            cloudflare_stop_tunnel "$APP_NAME" "$ENV_NAME" || true
+            cloudflare_run_tunnel "$APP_NAME" "$ENV_NAME" "$token"
+          else
+            log_info "Tunnel will start with updated config."
+          fi
         else
           log_warn "Multiple Docker ports found after deploy: $post_list"
           log_info "Choose ports explicitly: fb bootstrap --site-port <site> --api-port <api>"
@@ -370,11 +477,11 @@ cmd_bootstrap() {
   fi
 
   if [[ "$app_deployed" == "true" ]]; then
-    if [[ -n "$SITE_PORT" ]]; then
-      wait_for_http_ready "http://localhost:$SITE_PORT" "Local app" || true
-    fi
     if [[ -n "$DOMAIN_NAME" ]]; then
-      wait_for_http_ready "https://$DOMAIN_NAME" "Cloudflare" || true
+      local cf_url="https://$DOMAIN_NAME"
+      wait_for_http_ready "$cf_url" "Cloudflare" "true" || true
+      local cf_ready_url
+      cf_ready_url="$(resolve_ready_url "$cf_url")"
     fi
   elif [[ "$manual_mode" != "true" ]]; then
     log_warn "Skipping readiness checks (app not deployed)."

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -84,6 +84,21 @@ cmd_self_uninstall() {
     log_warn "fb binary not found at $bin_path"
   fi
   if [[ -d "$FB_HOME" ]]; then
+    local envs=""
+    envs="$(find "$FB_HOME" -path "$FB_HOME/runtime" -prune -o -type f \( -name config.yml -o -name ports.json -o -name tunnel.token -o -name cloudflared.pid \) -print 2>/dev/null \
+      | awk -F'/' '{print $(NF-2) "/" $(NF-1)}' \
+      | sort -u)"
+    if [[ -n "$envs" ]]; then
+      log_warn "Detected app environments under $FB_HOME:"
+      while IFS= read -r env; do
+        log_warn "  $env"
+      done <<<"$envs"
+      log_warn "To clean up:"
+      log_warn "  fb app list"
+      log_warn "  fb app down --purge <app>/<env>"
+    fi
+  fi
+  if [[ -d "$FB_HOME" ]]; then
     rm -rf "$FB_HOME"
     log_info "Removed $FB_HOME"
   fi


### PR DESCRIPTION
Same CF tunnel name enforces the HA(Load balancing) behavior against the same Zone(even though different subdomain). 

The fix was the FB append a suffix hash the CF tunnel name since FB is not planing to support the HA in the near future. 