### PR TITLE
14 - part 2 to support plugin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ fb self uninstall
 
 # optional (Early Access only)
 fb self update
+fb self update --with-plugins
 fb license status
 fb activate <license-key>
 ```

--- a/cmd/fb
+++ b/cmd/fb
@@ -32,6 +32,8 @@ source "$FB_ROOT/lib/list.sh"
 source "$FB_ROOT/lib/app.sh"
 # shellcheck source=lib/plugins.sh
 source "$FB_ROOT/lib/plugins.sh"
+# shellcheck source=lib/plugin_manager.sh
+source "$FB_ROOT/lib/plugin_manager.sh"
 
 show_help() {
   cat <<'EOF'
@@ -115,6 +117,10 @@ case "$cmd" in
         die "Usage: fb license status"
         ;;
     esac
+    ;;
+  plugin)
+    shift
+    cmd_plugin "$@"
     ;;
   help|-h|--help|"")
     show_help

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -31,3 +31,32 @@ The example plugin prints its arguments and a couple of context variables passed
 - `FOUNDERBOOSTER_VERSION`
 - `FOUNDERBOOSTER_STATE_ROOT`
 - `FOUNDERBOOSTER_CWD`
+
+## Plugin install/update (Early Access)
+
+FounderBooster supports an optional plugin installer for Early Access users. It downloads plugin manifests from
+`downloads.founderbooster.com` (or your configured downloads base URL) and installs plugins into:
+`~/.founderbooster/plugins/`.
+
+Install a plugin:
+```bash
+fb activate <license-key>
+fb plugin install ttl
+```
+
+Update plugins:
+```bash
+fb plugin update ttl
+fb plugin update --all
+```
+
+You can also update plugins while updating core:
+```bash
+fb self update --with-plugins
+```
+
+List/remove plugins:
+```bash
+fb plugin list
+fb plugin remove ttl
+```

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -47,6 +47,11 @@ is_true() {
   esac
 }
 
+is_semver() {
+  local val="$1"
+  [[ "$val" =~ ^[0-9]+(\.[0-9]+)*$ ]]
+}
+
 safe_basename() {
   local path="$1"
   basename "$path"
@@ -85,4 +90,37 @@ FounderBooster is open source.
 Optional lifetime Early Access licenses are available for users who want prebuilt binaries, automatic updates, and early access to advanced features.
 $EARLY_ACCESS_URL
 EOF
+}
+
+downloads_base_url() {
+  local base=""
+  if [[ -f "$FB_HOME/download_base_url" ]]; then
+    base="$(cat "$FB_HOME/download_base_url")"
+  fi
+  echo "${FB_DOWNLOAD_BASE_URL:-${DOWNLOAD_BASE_URL:-${base:-https://downloads.founderbooster.com}}}"
+}
+
+version_ge() {
+  local a="$1"
+  local b="$2"
+  local IFS=.
+  local -a va vb
+  read -r -a va <<<"$a"
+  read -r -a vb <<<"$b"
+  local i max
+  max="${#va[@]}"
+  if (( ${#vb[@]} > max )); then
+    max="${#vb[@]}"
+  fi
+  for ((i=0; i<max; i++)); do
+    local ai="${va[i]:-0}"
+    local bi="${vb[i]:-0}"
+    if (( ai > bi )); then
+      return 0
+    fi
+    if (( ai < bi )); then
+      return 1
+    fi
+  done
+  return 0
 }

--- a/lib/license.sh
+++ b/lib/license.sh
@@ -1,7 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+init_license_context() {
+  if [[ -z "${FB_HOME:-}" ]]; then
+    FB_HOME="${FOUNDERBOOSTER_HOME:-$HOME/.founderbooster}"
+  fi
+  if [[ -z "${FB_ROOT:-}" ]]; then
+    if [[ -n "${FOUNDERBOOSTER_HOME:-}" && -d "${FOUNDERBOOSTER_HOME}/runtime/lib" ]]; then
+      FB_ROOT="${FOUNDERBOOSTER_HOME}/runtime"
+    elif [[ -n "${FB_HOME:-}" && -d "${FB_HOME}/runtime/lib" ]]; then
+      FB_ROOT="${FB_HOME}/runtime"
+    else
+      FB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    fi
+  fi
+  if ! command -v log_error >/dev/null 2>&1; then
+    if [[ -f "$FB_ROOT/lib/common.sh" ]]; then
+      # shellcheck source=lib/common.sh
+      source "$FB_ROOT/lib/common.sh"
+    else
+      log_error() { echo "ERROR: $*" >&2; }
+      die() { log_error "$@"; exit 1; }
+      ensure_dir() { mkdir -p "$1"; }
+    fi
+  fi
+}
+
 license_path() {
+  init_license_context
+  if [[ -n "${FOUNDERBOOSTER_LICENSE_PATH:-}" ]]; then
+    echo "$FOUNDERBOOSTER_LICENSE_PATH"
+    return 0
+  fi
   echo "$FB_HOME/license.key"
 }
 

--- a/lib/plugin_manager.sh
+++ b/lib/plugin_manager.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_help() {
+  cat <<'EOF'
+Usage: fb plugin <command>
+
+Commands:
+  install <name>      Install or update a plugin (Early Access)
+  update <name>       Update a plugin (Early Access)
+  update --all        Update all installed plugins (Early Access)
+  list                List installed plugins
+  remove <name>       Remove a plugin
+EOF
+}
+
+plugin_install_help() {
+  cat <<'EOF'
+Usage: fb plugin install <name>
+EOF
+}
+
+plugin_update_help() {
+  cat <<'EOF'
+Usage: fb plugin update <name>|--all
+EOF
+}
+
+plugin_remove_help() {
+  cat <<'EOF'
+Usage: fb plugin remove <name>
+EOF
+}
+
+plugin_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$os" in
+    darwin|linux) ;;
+    *) die "Unsupported OS: $os" ;;
+  esac
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) die "Unsupported arch: $arch" ;;
+  esac
+  echo "$os-$arch"
+}
+
+plugin_manifest_value() {
+  local file="$1"
+  local key="$2"
+  awk -F'"' -v k="$key" '$2==k {print $4; exit}' "$file"
+}
+
+plugin_manifest_platform_value() {
+  local file="$1"
+  local platform="$2"
+  local key="$3"
+  awk -v platform="$platform" -v key="$key" '
+    $0 ~ "\""platform"\"" {in_platform=1}
+    in_platform && $0 ~ "\""key"\"" {
+      gsub(/.*"'"$key"'":[[:space:]]*"/,"")
+      gsub(/".*/,"")
+      print
+      exit
+    }
+    in_platform && $0 ~ /^[[:space:]]*}/ {in_platform=0}
+  ' "$file"
+}
+
+sha256_hash() {
+  local file="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return 0
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return 0
+  fi
+  die "Missing shasum or sha256sum."
+}
+
+plugin_install() {
+  local name="$1"
+  if [[ -z "$name" ]]; then
+    plugin_install_help
+    return 1
+  fi
+
+  require_license
+  require_cmd curl
+  require_cmd tar
+
+  local base_url
+  base_url="$(downloads_base_url)"
+  local manifest_url="$base_url/plugins/$name/manifest.json"
+  local manifest tmp_dir
+  tmp_dir="$(mktemp -d)"
+  manifest="$tmp_dir/manifest.json"
+
+  if ! curl -fsSL "$manifest_url" -o "$manifest"; then
+    rm -rf "$tmp_dir"
+    die "Failed to download plugin manifest: $manifest_url"
+  fi
+
+  local latest min_core manifest_base
+  latest="$(plugin_manifest_value "$manifest" "latest")"
+  min_core="$(plugin_manifest_value "$manifest" "min_core_version")"
+  manifest_base="$(plugin_manifest_value "$manifest" "download_base_url")"
+  manifest_base="${manifest_base:-$base_url}"
+
+  if [[ -z "$latest" ]]; then
+    rm -rf "$tmp_dir"
+    die "Plugin manifest missing latest version."
+  fi
+  if [[ -n "$min_core" ]]; then
+    local current
+    current="$(cmd_version)"
+    if is_semver "$current" && is_semver "$min_core"; then
+      if ! version_ge "$current" "$min_core"; then
+        rm -rf "$tmp_dir"
+        die "Plugin requires FounderBooster $min_core+. Run: fb self update"
+      fi
+    else
+      log_warn "Skipping min_core_version check (non-semver core version: $current)."
+    fi
+  fi
+
+  local platform
+  platform="$(plugin_platform)"
+  local tarball_path sha_path
+  tarball_path="$(plugin_manifest_platform_value "$manifest" "$platform" "tarball")"
+  sha_path="$(plugin_manifest_platform_value "$manifest" "$platform" "sha256")"
+  if [[ -z "$tarball_path" || -z "$sha_path" ]]; then
+    rm -rf "$tmp_dir"
+    die "Plugin manifest missing platform entry for $platform"
+  fi
+
+  local tarball_url="$manifest_base/$tarball_path"
+  local sha_url="$manifest_base/$sha_path"
+  local tarball_file="$tmp_dir/$(basename "$tarball_path")"
+  local sha_file="$tmp_dir/$(basename "$sha_path")"
+
+  if ! curl -fsSL "$tarball_url" -o "$tarball_file"; then
+    rm -rf "$tmp_dir"
+    die "Failed to download plugin tarball: $tarball_url"
+  fi
+  if ! curl -fsSL "$sha_url" -o "$sha_file"; then
+    rm -rf "$tmp_dir"
+    die "Failed to download plugin checksum: $sha_url"
+  fi
+
+  local expected actual
+  expected="$(awk '{print $1; exit}' "$sha_file")"
+  actual="$(sha256_hash "$tarball_file")"
+  if [[ -z "$expected" || "$expected" != "$actual" ]]; then
+    rm -rf "$tmp_dir"
+    die "Checksum verification failed for $tarball_file"
+  fi
+
+  local extract_dir="$tmp_dir/extract"
+  mkdir -p "$extract_dir"
+  tar -xzf "$tarball_file" -C "$extract_dir"
+
+  local plugin_bin="fb-plugin-$name"
+  local found
+  found="$(find "$extract_dir" -type f -name "$plugin_bin" -maxdepth 4 | head -n1)"
+  if [[ -z "$found" ]]; then
+    rm -rf "$tmp_dir"
+    die "Plugin binary not found in tarball: $plugin_bin"
+  fi
+
+  local dest_dir="$FB_HOME/plugins"
+  ensure_dir "$dest_dir"
+  local dest="$dest_dir/$plugin_bin"
+  cp "$found" "$dest"
+  chmod +x "$dest"
+  printf '%s\n' "$latest" >"$dest_dir/${name}.version"
+
+  rm -rf "$tmp_dir"
+  log_info "Installed plugin $name ($latest)"
+}
+
+plugin_remove() {
+  local name="$1"
+  if [[ -z "$name" ]]; then
+    plugin_remove_help
+    return 1
+  fi
+  local dest_dir="$FB_HOME/plugins"
+  local plugin_bin="$dest_dir/fb-plugin-$name"
+  if [[ -f "$plugin_bin" ]]; then
+    rm -f "$plugin_bin"
+    rm -f "$dest_dir/${name}.version"
+    log_info "Removed plugin $name"
+    return 0
+  fi
+  log_warn "Plugin not found: $name"
+}
+
+plugin_list() {
+  local dir="$FB_HOME/plugins"
+  if [[ ! -d "$dir" ]]; then
+    log_warn "No plugins installed."
+    return 0
+  fi
+  local entries
+  entries="$(find "$dir" -maxdepth 1 -type f -name 'fb-plugin-*' 2>/dev/null | sort || true)"
+  if [[ -z "$entries" ]]; then
+    log_warn "No plugins installed."
+    return 0
+  fi
+  while IFS= read -r plugin_path; do
+    [[ -z "$plugin_path" ]] && continue
+    local base name version_file version
+    base="$(basename "$plugin_path")"
+    name="${base#fb-plugin-}"
+    version_file="$dir/${name}.version"
+    version="unknown"
+    if [[ -f "$version_file" ]]; then
+      version="$(cat "$version_file")"
+    fi
+    echo "$name - version=$version"
+  done <<<"$entries"
+}
+
+plugin_update_all() {
+  require_license
+  local dir="$FB_HOME/plugins"
+  if [[ ! -d "$dir" ]]; then
+    log_warn "No plugins installed."
+    return 0
+  fi
+  local entries
+  entries="$(find "$dir" -maxdepth 1 -type f -name 'fb-plugin-*' 2>/dev/null | sort || true)"
+  if [[ -z "$entries" ]]; then
+    log_warn "No plugins installed."
+    return 0
+  fi
+  while IFS= read -r plugin_path; do
+    [[ -z "$plugin_path" ]] && continue
+    local base name
+    base="$(basename "$plugin_path")"
+    name="${base#fb-plugin-}"
+    plugin_install "$name"
+  done <<<"$entries"
+}
+
+cmd_plugin() {
+  local sub="${1:-}"
+  case "$sub" in
+    install)
+      shift
+      plugin_install "${1:-}"
+      ;;
+    update)
+      shift
+      if [[ "${1:-}" == "--all" ]]; then
+        plugin_update_all
+      else
+        plugin_install "${1:-}"
+      fi
+      ;;
+    list)
+      shift
+      plugin_list
+      ;;
+    remove)
+      shift
+      plugin_remove "${1:-}"
+      ;;
+    help|-h|--help|"")
+      plugin_help
+      ;;
+    *)
+      die "Unknown plugin command: $sub"
+      ;;
+  esac
+}

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -27,11 +27,24 @@ EOF
 }
 
 cmd_self_update() {
-  local base_url=""
-  if [[ -f "$FB_HOME/download_base_url" ]]; then
-    base_url="$(cat "$FB_HOME/download_base_url")"
-  fi
-  base_url="${FB_DOWNLOAD_BASE_URL:-${DOWNLOAD_BASE_URL:-${base_url:-https://downloads.founderbooster.com}}}"
+  local base_url
+  local with_plugins="false"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --with-plugins)
+        with_plugins="true"
+        shift
+        ;;
+      -h|--help)
+        echo "Usage: fb self update [--with-plugins]"
+        return 0
+        ;;
+      *)
+        die "Unknown option: $1"
+        ;;
+    esac
+  done
+  base_url="$(downloads_base_url)"
   require_license
   local manifest
   manifest="$(mktemp)"
@@ -61,6 +74,10 @@ cmd_self_update() {
   fi
   bash "$installer"
   rm -f "$installer"
+
+  if is_true "$with_plugins"; then
+    cmd_plugin update --all || true
+  fi
 }
 
 cmd_self_uninstall() {

--- a/public/install.sh
+++ b/public/install.sh
@@ -154,6 +154,7 @@ runtime_dir="$HOME/.founderbooster/runtime"
 mkdir -p "$runtime_dir/lib" "$runtime_dir/templates"
 cp -R "$pkg_dir/lib/." "$runtime_dir/lib/"
 cp -R "$pkg_dir/templates/." "$runtime_dir/templates/"
+chmod +x "$runtime_dir/lib/license.sh" 2>/dev/null || true
 
 mkdir -p "$HOME/.founderbooster"
 cp "$pkg_dir/VERSION" "$HOME/.founderbooster/VERSION"

--- a/tests/integration/_helpers.sh
+++ b/tests/integration/_helpers.sh
@@ -215,4 +215,6 @@ source_libs() {
   source "$ROOT_DIR/lib/list.sh"
   # shellcheck source=lib/app.sh
   source "$ROOT_DIR/lib/app.sh"
+  # shellcheck source=lib/plugin_manager.sh
+  source "$ROOT_DIR/lib/plugin_manager.sh"
 }

--- a/tests/integration/plugin_install.sh
+++ b/tests/integration/plugin_install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_helpers.sh"
+
+integration_init
+source_libs
+
+require_license() { return 0; }
+cmd_version() { echo "0.1.0"; }
+
+manifest_path="$TMP_DIR/manifest.json"
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+esac
+platform="${os}-${arch}"
+tarball_name="fb-plugin-ttl-0.1.0-${platform}.tar.gz"
+tarball_path="$TMP_DIR/$tarball_name"
+sha_path="$TMP_DIR/$tarball_name.sha256"
+
+cat >"$manifest_path" <<JSON
+{
+  "latest": "0.1.0",
+  "min_core_version": "0.0.1",
+  "download_base_url": "https://downloads.example.com",
+  "platforms": {
+    "${platform}": {
+      "tarball": "plugins/ttl/releases/0.1.0/${tarball_name}",
+      "sha256":  "plugins/ttl/releases/0.1.0/${tarball_name}.sha256"
+    }
+  }
+}
+JSON
+
+pkg_dir="$TMP_DIR/pkg"
+mkdir -p "$pkg_dir"
+cat >"$pkg_dir/fb-plugin-ttl" <<'SH'
+#!/usr/bin/env bash
+echo "ttl"
+SH
+chmod +x "$pkg_dir/fb-plugin-ttl"
+tar -czf "$tarball_path" -C "$pkg_dir" fb-plugin-ttl
+if command -v shasum >/dev/null 2>&1; then
+  expected_hash="$(shasum -a 256 "$tarball_path" | awk '{print $1}')"
+else
+  expected_hash="$(sha256sum "$tarball_path" | awk '{print $1}')"
+fi
+printf '%s  %s\n' "$expected_hash" "$(basename "$tarball_path")" >"$sha_path"
+
+cat >"$STUB_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+dest=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      dest="$2"
+      shift 2
+      ;;
+    http*://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -z "$dest" || -z "$url" ]]; then
+  exit 1
+fi
+case "$url" in
+  */manifest.json)
+    cp "$TEST_MANIFEST_PATH" "$dest"
+    ;;
+  *.tar.gz)
+    cp "$TEST_TARBALL_PATH" "$dest"
+    ;;
+  *.sha256)
+    cp "$TEST_SHA_PATH" "$dest"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$STUB_BIN/curl"
+
+export TEST_MANIFEST_PATH="$manifest_path"
+export TEST_TARBALL_PATH="$tarball_path"
+export TEST_SHA_PATH="$sha_path"
+export FB_DOWNLOAD_BASE_URL="https://downloads.example.com"
+
+output="$(plugin_install ttl)"
+OUTPUT_DUMP="$output"
+
+assert_contains "$output" "Installed plugin ttl (0.1.0)"
+assert_true "[[ -x \"$FB_HOME/plugins/fb-plugin-ttl\" ]]" "plugin binary installed"
+assert_true "[[ \"$(cat "$FB_HOME/plugins/ttl.version")\" == \"0.1.0\" ]]" "version file written"
+
+echo "plugin_install.sh OK"

--- a/tests/integration/self_update.sh
+++ b/tests/integration/self_update.sh
@@ -55,9 +55,13 @@ chmod +x "$TEST_INSTALLER_PATH"
 
 stub_curl_self_update
 
-output="$(cmd_self_update)"
+plugin_update_flag="$TMP_DIR/plugins-updated"
+plugin_update_all() { printf 'updated' >"$plugin_update_flag"; }
+
+output="$(cmd_self_update --with-plugins)"
 OUTPUT_DUMP="$output"
 
 assert_true "[[ \"$(cat "$FB_HOME/VERSION")\" == \"0.0.2\" ]]" "version updated"
+assert_true "[[ -f \"$plugin_update_flag\" ]]" "plugins updated"
 
 echo "self_update.sh OK"

--- a/tests/unit/plugin_test.sh
+++ b/tests/unit/plugin_test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERT_CONTAINS failed: missing '$needle'" >&2
+    exit 1
+  fi
+}
+
+assert_true() {
+  local condition="$1"
+  local msg="${2:-}"
+  if ! eval "$condition"; then
+    echo "ASSERT_TRUE failed: $condition $msg" >&2
+    exit 1
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+source "$ROOT_DIR/lib/common.sh"
+source "$ROOT_DIR/lib/plugin_manager.sh"
+
+export FB_HOME="$TMP_DIR/fb-home"
+mkdir -p "$FB_HOME"
+
+require_license() { return 0; }
+cmd_version() { echo "0.1.0"; }
+
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$STUB_BIN"
+export PATH="$STUB_BIN:$PATH"
+
+manifest_path="$TMP_DIR/manifest.json"
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+esac
+platform="${os}-${arch}"
+tarball_name="fb-plugin-ttl-0.1.0-${platform}.tar.gz"
+tarball_path="$TMP_DIR/$tarball_name"
+sha_path="$TMP_DIR/$tarball_name.sha256"
+
+cat >"$manifest_path" <<JSON
+{
+  "latest": "0.1.0",
+  "min_core_version": "0.0.1",
+  "download_base_url": "https://downloads.example.com",
+  "platforms": {
+    "${platform}": {
+      "tarball": "plugins/ttl/releases/0.1.0/${tarball_name}",
+      "sha256":  "plugins/ttl/releases/0.1.0/${tarball_name}.sha256"
+    }
+  }
+}
+JSON
+
+pkg_dir="$TMP_DIR/pkg"
+mkdir -p "$pkg_dir"
+cat >"$pkg_dir/fb-plugin-ttl" <<'SH'
+#!/usr/bin/env bash
+echo "ttl"
+SH
+chmod +x "$pkg_dir/fb-plugin-ttl"
+tar -czf "$tarball_path" -C "$pkg_dir" fb-plugin-ttl
+if command -v shasum >/dev/null 2>&1; then
+  expected_hash="$(shasum -a 256 "$tarball_path" | awk '{print $1}')"
+else
+  expected_hash="$(sha256sum "$tarball_path" | awk '{print $1}')"
+fi
+printf '%s  %s\n' "$expected_hash" "$(basename "$tarball_path")" >"$sha_path"
+
+cat >"$STUB_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+dest=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      dest="$2"
+      shift 2
+      ;;
+    http*://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -z "$dest" || -z "$url" ]]; then
+  exit 1
+fi
+case "$url" in
+  */manifest.json)
+    cp "$TEST_MANIFEST_PATH" "$dest"
+    ;;
+  *.tar.gz)
+    cp "$TEST_TARBALL_PATH" "$dest"
+    ;;
+  *.sha256)
+    cp "$TEST_SHA_PATH" "$dest"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$STUB_BIN/curl"
+
+export TEST_MANIFEST_PATH="$manifest_path"
+export TEST_TARBALL_PATH="$tarball_path"
+export TEST_SHA_PATH="$sha_path"
+export FB_DOWNLOAD_BASE_URL="https://downloads.example.com"
+
+output="$(plugin_install ttl)"
+assert_contains "$output" "Installed plugin ttl (0.1.0)"
+assert_true "[[ -x \"$FB_HOME/plugins/fb-plugin-ttl\" ]]" "plugin binary installed"
+assert_true "[[ \"$(cat "$FB_HOME/plugins/ttl.version")\" == \"0.1.0\" ]]" "version file written"
+
+list_output="$(plugin_list)"
+assert_contains "$list_output" "ttl - version=0.1.0"
+
+cat >"$manifest_path" <<JSON
+{
+  "latest": "0.1.0",
+  "min_core_version": "0.2.0",
+  "download_base_url": "https://downloads.example.com",
+  "platforms": {
+    "${platform}": {
+      "tarball": "plugins/ttl/releases/0.1.0/${tarball_name}",
+      "sha256":  "plugins/ttl/releases/0.1.0/${tarball_name}.sha256"
+    }
+  }
+}
+JSON
+
+if (plugin_install ttl >/dev/null 2>&1); then
+  echo "ASSERT_TRUE failed: expected min_core_version to block install" >&2
+  exit 1
+fi
+
+touch "$FB_HOME/plugins/fb-plugin-foo"
+touch "$FB_HOME/plugins/fb-plugin-bar"
+plugin_calls="$TMP_DIR/plugin_calls"
+plugin_install() { echo "$1" >>"$plugin_calls"; }
+plugin_update_all
+
+assert_true "grep -qx \"foo\" \"$plugin_calls\"" "update all installs foo"
+assert_true "grep -qx \"bar\" \"$plugin_calls\"" "update all installs bar"
+
+echo "plugin_test.sh OK"


### PR DESCRIPTION
   - Added plugin manager (fb plugin install/update/list/remove) with EA gating, checksum verification, and min_core_version checks.
   - Added fb self update --with-plugins and shared helpers (downloads_base_url, semver comparison).
   - Expanded tests: new unit test for plugin manager, integration coverage for plugin install and --with-plugins.
   - Added E2E harness and docs update.
   - Fix plugin license verification and runtime install permissions